### PR TITLE
Add two-stage build process to PyCont

### DIFF
--- a/PyDSTool/PyCont/ContClass.py
+++ b/PyDSTool/PyCont/ContClass.py
@@ -424,7 +424,7 @@ class ContClass(Utility):
                 print("Then load the Auto module using the importAutoMod method")
 
         if not nobuild:
-            self.importAutoMod()
+            self.importAutoLib()
 
     def importAutoLib(self):
         """


### PR DESCRIPTION
I just modified the ContClass::loadAutoMod method to enable a two-stage build process.
This is similar to what is done in the Radau integrator code and this allow using custom C code in the rhs specification.

The main difference with the integrator two-stage process is that once the library has been compiledis also need to be imported using the "importAutoLib".
I could also add this method into "makeAutoLib" which currently combine the source creation and the compilation.
