### PR TITLE
Stop forcing Python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ matrix:
             - NUMPY_SPEC=numpy
             - SCIPY_SPEC=scipy
             - COVERAGE="yes"
-        - python: 2.6
-          env:
-            - NUMPY_SPEC='numpy<1.9'
-            - SCIPY_SPEC=scipy
-            - COVERAGE="no"
 
 before_install:
     - uname -a

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ See more at `pydstool.sourceforge.net <http://pydstool.sourceforge.net>`__.
 Requirements
 ~~~~~~~~~~~~
 
-*  `Python <http://www.python.org>`__ 2.6+ or 3.3+;
+*  `Python <http://www.python.org>`__ 2.7 or 3.3+;
 *  `numpy <http://www.numpy.org>`__;
 *  `scipy <http://www.scipy.org>`__.
 

--- a/WHATS_NEW.txt
+++ b/WHATS_NEW.txt
@@ -11,6 +11,7 @@ version 0.??
 * Standard Python installer using `python setup.py install`
 * Make Dopri/Radau compilable by Clang
 * Port Dopri/Radau from NumArray to NumPy to support numpy-1.9+
+* Drop Python 2.6 support
 
 version 0.88 02 Dec 2012
 ---------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py27, py33, py34
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
Python 2.6 is not supported officially more than year already.
This commit removes Python 2.6 environments from 'Travis' and 'tox'
settings. It **does not** make PyDSTool unusable on Python 2.6. It just
stops forcing new changes to be Python 2.6 compatible.
