### PR TITLE
Updated Symbolic.expr2fun and associated regression tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,10 @@ matrix:
             - COVERAGE="yes"
 
 before_install:
-    - uname -a
-    - python -c 'import struct; print(struct.calcsize("P") * 8)'
     - sudo apt-get update -qq
     - sudo apt-get install -qq liblapack-dev libatlas-dev libatlas-base-dev gfortran swig
-    - pip install --upgrade pip setuptools pytest pytest-xdist
-    - pip install --use-wheel six
-    - export PIP_CMD='pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel'
+    - pip install --use-wheel pytest pytest-xdist six mock
+    - export PIP_CMD='pip install --use-wheel'
 
 install:
     - $PIP_CMD $NUMPY_SPEC

--- a/tests/test_symbolic.py
+++ b/tests/test_symbolic.py
@@ -100,6 +100,14 @@ def test_symbolic():
     k = expr2fun('-f(c,d)+b', f=fnspec['f'], b=0.5, a=1)
     assert k(1,2) == -4.5
 
+    # alternate scope and testing embedded dynamic pars in both
+    # main expression and sub-expressions like f()
+    l = expr2fun('-f(c,d)+b', ensure_dynamic={'a':1, 'c':2},
+                 **fnspec)
+    assert l._args == ['d', 'b']
+    assert l._call_spec == "-self.f(self._pardict['c'],d)+b"
+    assert l(1,2) == -2
+
     s='1+a/(f(x,y)-3)+h(2)'
     t=s.replace('y','g(x,z)')
     u=t.replace('z','f(z)')


### PR DESCRIPTION
Updated Symbolic.expr2fun to only test evaluate qexpr if valDict non-empty and add \__name\__, etc.
Add test_symbolic test case for ensure_dynamic for expr2fun with string-based input (Jac usage has been with Fun input only - possible bug present)