### PR TITLE
Fix bug in NonHybridModel.AuxVars method

### DIFF
--- a/PyDSTool/Model.py
+++ b/PyDSTool/Model.py
@@ -1861,6 +1861,7 @@ class NonHybridModel(Model):
           asarray  (Bool, optional, default False) If true, will return an array
                    in state name alphabetical order, else a Point
         """
+        ds = list(self.registry.values())[0]
         fscm = ds._FScompatibleNames
         fscmInv = ds._FScompatibleNamesInv
         x_fs = filteredDict(fscm(xdict), ds.get('funcspec').vars)


### PR DESCRIPTION
With P1 being a ContClass instance and cur a EquilibriumCurve :
```
In [33]: P1.model.AuxVars(0., cur.sol[0])
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-33-c5f2d79a4d6e> in <module>()
----> 1 P1.model.AuxVars(0., cur.sol[0])

/usr/local/lib/python2.7/dist-packages/PyDSTool-0.90.0-py2.7.egg/PyDSTool/Model.pyc in AuxVars(self, t, xdict, pdict, asarray)
   1847                    in state name alphabetical order, else a Point
   1848         """
-> 1849         fscm = ds._FScompatibleNames
   1850         fscmInv = ds._FScompatibleNamesInv
   1851         x_fs = filteredDict(fscm(xdict), ds.get('funcspec').vars)

NameError: global name 'ds' is not defined

The commit defines the ds object in the manner of the other methods of NonHybrid Model