### PR TITLE
Nineml catalog test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ PyDSTool.egg-info/
 .project
 .pydevproject
 .settings
+.DS_Store

--- a/PyDSTool/Toolbox/NineML.py
+++ b/PyDSTool/Toolbox/NineML.py
@@ -207,7 +207,7 @@ def get_nineml_model(c, model_name, target='Vode', extra_args=None,
             else:
                 raise ValueError("Event type not implemented!")
             new_defstr = ''.join(toks[:ix]) + '-' + '(' + ''.join(toks[ix+1:]) + ')'
-            evnames = [eo.port_name for eo in e.event_outputs]
+            evnames = [oe.port_name for oe in e.output_events]
             if evnames == []:
                 # no outputs, must create an event name based on LHS of trigger condition
                 if "".join(toks[:ix]) == 't':

--- a/PyDSTool/Toolbox/NineML.py
+++ b/PyDSTool/Toolbox/NineML.py
@@ -30,7 +30,7 @@ __all__ = _functions + _classes + _features
 # ----------------------------------------------------------------------------
 
 try:
-    import nineml.abstraction_layer as al
+    import nineml.abstraction as al
 except ImportError:
     raise ImportError("NineML python API is needed for this toolbox to work")
 

--- a/examples/NineMLCatalog_test.py
+++ b/examples/NineMLCatalog_test.py
@@ -1,0 +1,226 @@
+"""
+A module for loading and testing basic neuron models as described in the NineML
+Catalog (see http://github.com/INCF/NineMLCatalog)
+"""
+import ninemlcatalog
+from PyDSTool import Par
+from PyDSTool.Toolbox.NineML import get_nineml_model
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+def test_HH():
+    c = ninemlcatalog.lookup('/neuron/HodgkinHuxley/HodgkinHuxley')
+
+    # Convert to PyDSTool.ModelSpec and create NonHybridModel object
+    # Provide extra parameter Isyn which is missing from component definition
+    # in absence of any synaptic inputs coupled to the model membrane
+    HHmodel = get_nineml_model(c, 'HH_9ML', extra_args=[Par('iSyn')])
+
+    HHmodel.set(pars={'C': 1.0,
+                      'iSyn': 20.0,
+                      'celsius': 20.0,
+                      'ek': -90,
+                      'el': -65,
+                      'ena': 80,
+                      'gkbar': 30.0,
+                      'gl': 0.3,
+                      'gnabar': 130.0,
+                      'v_threshold': -40.0,
+                      'qfactor': 6.3,
+                      'tendegrees': 10.0,
+                      'm_alpha_A': -0.1,
+                      'm_alpha_V0': -40.0,
+                      'm_alpha_K': 10.0,
+                      'm_beta_A': 4.0,
+                      'm_beta_V0': -65.0,
+                      'm_beta_K': 18.0,
+                      'h_alpha_A': 0.07,
+                      'h_alpha_V0': -65.0,
+                      'h_alpha_K': 20.0,
+                      'h_beta_A': 1.0,
+                      'h_beta_V0': -35.0,
+                      'h_beta_K': 10.0,
+                      'n_alpha_A': -0.01,
+                      'n_alpha_V0': -55.0,
+                      'n_alpha_K': 10.0,
+                      'n_beta_A': 0.125,
+                      'n_beta_V0': -65.0,
+                      'n_beta_K': 80.0},
+                ics={'V': -70, 'm': 0.1, 'n': 0, 'h': 0.9},
+                tdata=[0, 15])
+
+    HHmodel.compute('HHtest', force=True)
+    pts = HHmodel.sample('HHtest')
+    plt.figure(1)
+    plt.plot(pts['t'], pts['V'], 'k')
+    plt.title('Hodgkin-Huxley membrane potential')
+
+    ev_info = pts.labels.by_label['Event:spikeoutput']
+    for ev_ix, ev_tdata in list(ev_info.items()):
+        plt.plot(ev_tdata['t'], pts[ev_ix]['V'], 'ko')
+
+    plt.xlabel('t')
+    plt.ylabel('V')
+
+
+def test_aeIF():
+    """Adaptive Integrate and Fire"""
+    c = ninemlcatalog.lookup('/neuron/AdaptiveExpIntegrateAndFire/'
+                             'AdaptiveExpIntegrateAndFire')
+
+    # Convert to PyDSTool.ModelSpec and create HybridModel object
+    # Provide extra parameter Isyn which is missing from component definition
+    # in absence of any synaptic inputs coupled to the model membrane
+    aeIF = get_nineml_model(c, 'aeIF_9ML', extra_args=[Par('Isyn')],
+                            max_t=100)
+
+    aeIF.set(pars=dict(
+        C_m=1,
+        g_L=0.1,
+        E_L=-65,
+        Delta=1,
+        V_T=-58,
+        S=0.1,
+        tspike=0.5,
+        trefractory=0.25,
+        tau_w=4,
+        a=1,
+        b=2,
+        Isyn=5))
+
+    aeIF.set(ics={'V': -70, 'w': 0.1, 'regime_': 0},
+             tdata=[0, 30],
+             algparams={'init_step': 0.04})
+
+    aeIF.compute('test', verboselevel=0)
+
+    pts = aeIF.sample('test', dt=0.1)
+
+    plt.figure(2)
+    plt.plot(pts['t'], pts['V'])
+    plt.xlabel('t')
+    plt.ylabel('V')
+    plt.title('adaptive IF model')
+    plt.figure(3)
+    plt.plot(pts['t'], pts['w'])
+    plt.xlabel('t')
+    plt.ylabel('w')
+    plt.title('adaptive IF model')
+
+
+def test_Izh():
+    """Basic Izhikevich hybrid model"""
+    c = ninemlcatalog.lookup('/neuron/Izhikevich/Izhikevich')
+
+    # Convert to PyDSTool.ModelSpec and create HybridModel object
+    # Provide extra parameter Isyn which is missing from component definition
+    # in absence of any synaptic inputs coupled to the model membrane
+    izh = get_nineml_model(c, 'izh_9ML', extra_args=[Par('Isyn')],
+                            max_t=100)
+
+    izh.set(pars=dict(a=0.2, b=0.025, c=-75, d=0.2, theta=-50,
+                      Isyn=20, alpha=0.04, beta=5, zeta=140.0, C_m=1.0))
+    izh.set(ics={'V': -70, 'U': -1.625, 'regime_': 0},
+             tdata=[0, 80],
+             algparams={'init_step': 0.04})
+
+    izh.compute('test', verboselevel=0)
+
+    pts = izh.sample('test')
+
+    evs = izh.getTrajEventTimes('test')['spike']
+
+    theta = izh.query('pars')['theta']
+    plt.figure(4)
+    plt.plot(pts['t'], pts['V'], 'k')
+    plt.plot(evs, [theta] * len(evs), 'ko')
+    plt.title('Izhikevich model')
+    plt.xlabel('t')
+    plt.ylabel('V')
+
+    plt.figure(5)
+    plt.plot(pts['t'], pts['U'])
+    plt.xlabel('t')
+    plt.ylabel('U')
+    plt.title('Izhikevich model')
+
+# ========
+
+
+def test_Izh_FS(Iexts=None):
+    """Izhikevich Fast Spiker model"""
+    c = ninemlcatalog.lookup('/neuron/Izhikevich/IzhikevichFastSpiking')
+
+    # Convert to PyDSTool.ModelSpec and create HybridModel object
+    # Provide extra parameter Isyn which is missing from component definition
+    # in absence of any synaptic inputs coupled to the model membrane
+    izh = get_nineml_model(c, 'izh_9ML', extra_args=[Par('iSyn'), Par('iExt')],
+                            max_t=100)
+
+    if Iexts is None:
+        Iexts = [200]
+
+    izh.set(pars=dict(a=0.2, b=0.025, c=-45, k=1, Vpeak=25,
+                      Vb=-55, Cm=20, Vr=-55, Vt=-40))
+    # set starting regime to be sub-threshold (PyDSTool will check consistency
+    # with V initial condition)
+    izh.set(ics={'V': -65, 'U': -1.625, 'regime_': 0},
+             tdata=[0, 80],
+             algparams={'init_step': 0.03})
+
+    for Iext in Iexts:
+        izh.set(pars={'iExt': Iext})
+        name = 'Iext=%.1f' % (float(Iext))
+        izh.compute(name, verboselevel=0)
+        pts = izh.sample(name)
+        evs = izh.getTrajEventTimes(name)['spikeOutput']
+        ISIs = np.diff(evs)
+        print("Iext ={}:\n  Mean ISI = {}, variance = {}"
+              .format(Iext, np.mean(ISIs), np.var(ISIs)))
+
+        Vp = izh.query('pars')['Vpeak']
+        plt.figure(6)
+        plt.plot(pts['t'], pts['V'], label=name)
+        plt.plot(evs, [Vp] * len(evs), 'ko')
+        plt.title('Izhikevich fast spiking model')
+        plt.xlabel('t')
+        plt.ylabel('V')
+        plt.legend()
+
+        plt.figure(7)
+        plt.plot(pts['t'], pts['U'], label=name)
+        plt.xlabel('t')
+        plt.ylabel('U')
+        plt.legend()
+    plt.title('Izhikevich FS model')
+
+
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    parser = ArgumentParser()
+    parser.add_argument('test', type=str, nargs='+',
+                        help=("The name of the model to test. Can be either "
+                              "'hh', 'izhi', 'izhiFS' or 'aeif'."))
+    parser.add_argument('--injected_current', type=float, default=None,
+                        help=("The amount of current injected into the "
+                              "model(s) in nA."))
+    args = parser.parse_args()
+    for test in args.test:
+        if test == 'izhi':
+            test_Izh()
+        elif test == 'izhiFS':
+            if args.injected_current is None:
+                injected_current = [100, 200, 400]
+            else:
+                injected_current = [args.injected_current]
+            test_Izh_FS(injected_current)
+        elif test == 'aeif':
+            test_aeIF()
+        elif test == 'hh':
+            test_HH()
+        else:
+            raise Exception(
+                "Unrecognised test option '{}', can be either 'hh', 'izhi', "
+                "'izhiFS' or 'aeif'.")
+    plt.show()

--- a/examples/NineMLCatalog_test.py
+++ b/examples/NineMLCatalog_test.py
@@ -10,45 +10,18 @@ from matplotlib import pyplot as plt
 
 
 def test_HH():
-    c = ninemlcatalog.lookup('/neuron/HodgkinHuxley', 'HodgkinHuxley')
+    cc = ninemlcatalog.load('/neuron/HodgkinHuxley', 'HodgkinHuxley')
+    comp = ninemlcatalog.load('neuron/HodgkinHuxley', 'SampleHodgkinHuxley')
 
     # Convert to PyDSTool.ModelSpec and create NonHybridModel object
     # Provide extra parameter Isyn which is missing from component definition
     # in absence of any synaptic inputs coupled to the model membrane
-    HHmodel = get_nineml_model(c, 'HH_9ML', extra_args=[Par('iSyn')])
+    HHmodel = get_nineml_model(cc, 'HH_9ML', extra_args=[Par('isyn')])
 
-    HHmodel.set(pars={'C': 1.0,
-                      'iSyn': 20.0,
-                      'celsius': 20.0,
-                      'ek': -90,
-                      'el': -65,
-                      'ena': 80,
-                      'gkbar': 30.0,
-                      'gl': 0.3,
-                      'gnabar': 130.0,
-                      'v_threshold': -40.0,
-                      'qfactor': 6.3,
-                      'tendegrees': 10.0,
-                      'm_alpha_A': -0.1,
-                      'm_alpha_V0': -40.0,
-                      'm_alpha_K': 10.0,
-                      'm_beta_A': 4.0,
-                      'm_beta_V0': -65.0,
-                      'm_beta_K': 18.0,
-                      'h_alpha_A': 0.07,
-                      'h_alpha_V0': -65.0,
-                      'h_alpha_K': 20.0,
-                      'h_beta_A': 1.0,
-                      'h_beta_V0': -35.0,
-                      'h_beta_K': 10.0,
-                      'n_alpha_A': -0.01,
-                      'n_alpha_V0': -55.0,
-                      'n_alpha_K': 10.0,
-                      'n_beta_A': 0.125,
-                      'n_beta_V0': -65.0,
-                      'n_beta_K': 80.0},
-                ics={'V': -70, 'm': 0.1, 'n': 0, 'h': 0.9},
-                tdata=[0, 15])
+    pars = dict((p.name, p.value) for p in comp.properties)
+    pars['isyn'] = 20.0
+    ics = dict((i.name, i.value) for i in comp.initial_values)
+    HHmodel.set(pars=pars, ics=ics, tdata=[0, 15])
 
     HHmodel.compute('HHtest', force=True)
     pts = HHmodel.sample('HHtest')
@@ -66,32 +39,22 @@ def test_HH():
 
 def test_aeIF():
     """Adaptive Integrate and Fire"""
-    c = ninemlcatalog.lookup('/neuron/AdaptiveExpIntegrateAndFire',
-                             'AdaptiveExpIntegrateAndFire')
+    cc = ninemlcatalog.load('/neuron/AdaptiveExpIntegrateAndFire',
+                            'AdaptiveExpIntegrateAndFire')
+    comp = ninemlcatalog.load('/neuron/AdaptiveExpIntegrateAndFire',
+                              'SampleAdaptiveExpIntegrateAndFire')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
     # Provide extra parameter Isyn which is missing from component definition
     # in absence of any synaptic inputs coupled to the model membrane
-    aeIF = get_nineml_model(c, 'aeIF_9ML', extra_args=[Par('Isyn')],
+    aeIF = get_nineml_model(cc, 'aeIF_9ML', extra_args=[Par('Isyn')],
                             max_t=100)
 
-    aeIF.set(pars=dict(
-        C_m=1,
-        g_L=0.1,
-        E_L=-65,
-        Delta=1,
-        V_T=-58,
-        S=0.1,
-        tspike=0.5,
-        trefractory=0.25,
-        tau_w=4,
-        a=1,
-        b=2,
-        Isyn=5))
-
-    aeIF.set(ics={'V': -70, 'w': 0.1, 'regime_': 0},
-             tdata=[0, 30],
-             algparams={'init_step': 0.04})
+    pars = dict((p.name, p.value) for p in comp.properties)
+    pars['Isyn'] = 5.0
+    ics = dict((i.name, i.value) for i in comp.initial_values)
+    ics['regime_'] = 0
+    aeIF.set(pars=pars, ics=ics, tdata=[0, 30], algparams={'init_step': 0.04})
 
     aeIF.compute('test', verboselevel=0)
 
@@ -111,19 +74,20 @@ def test_aeIF():
 
 def test_Izh():
     """Basic Izhikevich hybrid model"""
-    c = ninemlcatalog.lookup('/neuron/Izhikevich', 'Izhikevich')
+    cc = ninemlcatalog.load('/neuron/Izhikevich', 'Izhikevich')
+    comp = ninemlcatalog.load('/neuron/Izhikevich', 'SampleIzhikevich')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
     # Provide extra parameter Isyn which is missing from component definition
     # in absence of any synaptic inputs coupled to the model membrane
-    izh = get_nineml_model(c, 'izh_9ML', extra_args=[Par('Isyn')],
-                            max_t=100)
+    izh = get_nineml_model(cc, 'izh_9ML', extra_args=[Par('Isyn')],
+                           max_t=100)
 
-    izh.set(pars=dict(a=0.2, b=0.025, c=-75, d=0.2, theta=-50,
-                      Isyn=20, alpha=0.04, beta=5, zeta=140.0, C_m=1.0))
-    izh.set(ics={'V': -70, 'U': -1.625, 'regime_': 0},
-             tdata=[0, 80],
-             algparams={'init_step': 0.04})
+    pars = dict((p.name, p.value) for p in comp.properties)
+    pars['Isyn'] = 20.0
+    ics = dict((i.name, i.value) for i in comp.initial_values)
+    ics['regime_'] = 0
+    izh.set(pars=pars, ics=ics, tdata=[0, 80], algparams={'init_step': 0.04})
 
     izh.compute('test', verboselevel=0)
 
@@ -148,36 +112,36 @@ def test_Izh():
 # ========
 
 
-def test_Izh_FS(Iexts=None):
+def test_Izh_FS(iSyns=None):
     """Izhikevich Fast Spiker model"""
-    c = ninemlcatalog.lookup('/neuron/Izhikevich', 'IzhikevichFastSpiking')
+    if iSyns is None:
+        iSyns = [200]
+
+    cc = ninemlcatalog.load('/neuron/Izhikevich', 'IzhikevichFastSpiking')
+    comp = ninemlcatalog.load('/neuron/Izhikevich',
+                              'SampleIzhikevichFastSpiking')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
     # Provide extra parameter Isyn which is missing from component definition
     # in absence of any synaptic inputs coupled to the model membrane
-    izh = get_nineml_model(c, 'izh_9ML', extra_args=[Par('iSyn'), Par('iExt')],
-                            max_t=100)
-
-    if Iexts is None:
-        Iexts = [200]
-
-    izh.set(pars=dict(a=0.2, b=0.025, c=-45, k=1, Vpeak=25,
-                      Vb=-55, Cm=20, Vr=-55, Vt=-40))
+    izh = get_nineml_model(cc, 'izh_FS_9ML', extra_args=[Par('iSyn')],
+                           max_t=100)
+    pars = dict((p.name, p.value) for p in comp.properties)
+    ics = dict((i.name, i.value) for i in comp.initial_values)
+    ics['regime_'] = 0
     # set starting regime to be sub-threshold (PyDSTool will check consistency
     # with V initial condition)
-    izh.set(ics={'V': -65, 'U': -1.625, 'regime_': 0},
-             tdata=[0, 80],
-             algparams={'init_step': 0.03})
+    izh.set(pars=pars, ics=ics, tdata=[0, 80], algparams={'init_step': 0.03})
 
-    for Iext in Iexts:
-        izh.set(pars={'iExt': Iext})
-        name = 'Iext=%.1f' % (float(Iext))
+    for iSyn in iSyns:
+        izh.set(pars={'iSyn': iSyn})
+        name = 'iSyn=%.1f' % (float(iSyn))
         izh.compute(name, verboselevel=0)
         pts = izh.sample(name)
         evs = izh.getTrajEventTimes(name)['spikeOutput']
         ISIs = np.diff(evs)
-        print("Iext ={}:\n  Mean ISI = {}, variance = {}"
-              .format(Iext, np.mean(ISIs), np.var(ISIs)))
+        print("iSyn ={}:\n  Mean ISI = {}, variance = {}"
+              .format(iSyn, np.mean(ISIs), np.var(ISIs)))
 
         Vp = izh.query('pars')['Vpeak']
         plt.figure(6)

--- a/examples/NineMLCatalog_test.py
+++ b/examples/NineMLCatalog_test.py
@@ -10,7 +10,7 @@ from matplotlib import pyplot as plt
 
 
 def test_HH():
-    c = ninemlcatalog.lookup('/neuron/HodgkinHuxley/HodgkinHuxley')
+    c = ninemlcatalog.lookup('/neuron/HodgkinHuxley', 'HodgkinHuxley')
 
     # Convert to PyDSTool.ModelSpec and create NonHybridModel object
     # Provide extra parameter Isyn which is missing from component definition
@@ -66,7 +66,7 @@ def test_HH():
 
 def test_aeIF():
     """Adaptive Integrate and Fire"""
-    c = ninemlcatalog.lookup('/neuron/AdaptiveExpIntegrateAndFire/'
+    c = ninemlcatalog.lookup('/neuron/AdaptiveExpIntegrateAndFire',
                              'AdaptiveExpIntegrateAndFire')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
@@ -111,7 +111,7 @@ def test_aeIF():
 
 def test_Izh():
     """Basic Izhikevich hybrid model"""
-    c = ninemlcatalog.lookup('/neuron/Izhikevich/Izhikevich')
+    c = ninemlcatalog.lookup('/neuron/Izhikevich', 'Izhikevich')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
     # Provide extra parameter Isyn which is missing from component definition
@@ -150,7 +150,7 @@ def test_Izh():
 
 def test_Izh_FS(Iexts=None):
     """Izhikevich Fast Spiker model"""
-    c = ninemlcatalog.lookup('/neuron/Izhikevich/IzhikevichFastSpiking')
+    c = ninemlcatalog.lookup('/neuron/Izhikevich', 'IzhikevichFastSpiking')
 
     # Convert to PyDSTool.ModelSpec and create HybridModel object
     # Provide extra parameter Isyn which is missing from component definition

--- a/examples/NineML_import_test.py
+++ b/examples/NineML_import_test.py
@@ -1,34 +1,35 @@
 from __future__ import print_function
 
 from PyDSTool import *  # @UnusedWildImport
-from nineml import abstraction as al
 from nineml import units as un
 from PyDSTool.Toolbox.NineML import *  # @UnusedWildImport
+from nineml import abstraction as al  # @Reimport
 import nineml
 
 
 def get_HH_component():
     """A Hodgkin-Huxley single neuron model.
     Written by Andrew Davison.
-    See http://phobos.incf.ki.se/src_rst/examples/examples_al_python.html#example-hh
+    See http://phobos.incf.ki.se/src_rst/
+              examples/examples_al_python.html#example-hh
     """
     aliases = [
         "q10 := 3.0**((celsius - qfactor)/tendegrees)",  # temperature correction factor @IgnorePep8
-        "alpha_m := alpha_m_A*(V-alpha_m_V0)/(exp(-(V-alpha_m_V0)/alpha_m_K) - 1.0)",  # m
+        "alpha_m := alpha_m_A*(V-alpha_m_V0)/(exp(-(V-alpha_m_V0)/alpha_m_K) - 1.0)",  # @IgnorePep8
         "beta_m := beta_m_A*exp(-(V-beta_m_V0)/beta_m_K)",
-        "mtau := 1/(q10*(alpha_m + beta_m))",
+        "mtau := 1.0/(q10*(alpha_m + beta_m))",
         "minf := alpha_m/(alpha_m + beta_m)",
-        "alpha_h := 0.07*exp(-(V+65.0)/20.0)",               # h
-        "beta_h := 1.0/(exp(-(V+35)/10.0) + 1.0)",
+        "alpha_h := alpha_h_A*exp(-(V-alpha_h_V0)/alpha_h_K)",
+        "beta_h := beta_h_A/(exp(-(V-beta_h_V0)/beta_h_K) + 1.0)",
         "htau := 1.0/(q10*(alpha_h + beta_h))",
         "hinf := alpha_h/(alpha_h + beta_h)",
-        "alpha_n := -0.01*(V+55.0)/(exp(-(V+55.0)/10.0) - 1.0)",  # n
-        "beta_n := 0.125*exp(-(V+65.0)/80.0)",
+        "alpha_n := alpha_n_A*(V-alpha_n_V0)/(exp(-(V-alpha_n_V0)/alpha_n_K) - 1.0)",  # @IgnorePep8
+        "beta_n := beta_n_A*exp(-(V-beta_n_V0)/beta_n_K)",
         "ntau := 1.0/(q10*(alpha_n + beta_n))",
         "ninf := alpha_n/(alpha_n + beta_n)",
-        "gna := gnabar*m*m*m*h",                       #
+        "gna := gnabar*m*m*m*h",
         "gk := gkbar*n*n*n*n",
-        "ina := gna*(ena - V)",                 # currents
+        "ina := gna*(ena - V)",
         "ik := gk*(ek - V)",
         "il := gl*(el - V )"]
 
@@ -39,6 +40,12 @@ def get_HH_component():
         "dV/dt = (ina + ik + il + Isyn)/C",
         transitions=al.On("V > theta", do=al.SpikeOutputEvent())
     )
+
+    state_variables = [
+        al.StateVariable('V', un.voltage),
+        al.StateVariable('m', un.dimensionless),
+        al.StateVariable('n', un.dimensionless),
+        al.StateVariable('h', un.dimensionless)]
 
     # the rest are not "parameters" but aliases, assigned vars, state vars,
     # indep vars, analog_analog_ports, etc.
@@ -53,33 +60,58 @@ def get_HH_component():
         al.Parameter('gl', un.conductance),
         al.Parameter('celsius', un.temperature)]
 
+    # These should really be parameters rather than constants, but just to
+    # match previous definitions they are implemented as constants.
     constants = [
         al.Constant('qfactor', 6.3, un.degC),
         al.Constant('tendegrees', 10.0, un.degC),
         al.Constant('alpha_m_A', -0.1, un.unitless / (un.ms * un.mV)),
         al.Constant('alpha_m_V0', -40.0, un.mV),
         al.Constant('alpha_m_K', 10.0, un.mV),
-        al.Constant('beta_m_A', 4.0, un.unitless / (un.ms * un.mV)),
+        al.Constant('beta_m_A', 4.0, un.unitless / un.ms),
         al.Constant('beta_m_V0', -65.0, un.mV),
         al.Constant('beta_m_K', 18.0, un.mV),
-        al.Constant('alpha_h_A', 0.07, un.unitless / (un.ms * un.mV)),
+        al.Constant('alpha_h_A', 0.07, un.unitless / un.ms),
         al.Constant('alpha_h_V0', -65.0, un.mV),
         al.Constant('alpha_h_K', 20.0, un.mV),
-        al.Constant('beta_h_A', 1.0, un.unitless / (un.ms * un.mV)),
+        al.Constant('beta_h_A', 1.0, un.unitless / un.ms),
         al.Constant('beta_h_V0', -35.0, un.mV),
         al.Constant('beta_h_K', 10.0, un.mV),
         al.Constant('alpha_n_A', -0.01, un.unitless / (un.ms * un.mV)),
         al.Constant('alpha_n_V0', -55.0, un.mV),
         al.Constant('alpha_n_K', 10.0, un.mV),
-        al.Constant('beta_n_A', 0.125, un.unitless / (un.ms * un.mV)),
+        al.Constant('beta_n_A', 0.125, un.unitless / un.ms),
         al.Constant('beta_n_V0', -65.0, un.mV),
         al.Constant('beta_n_K', 80.0, un.mV)]
+    
+    constants = [
+        ul.Property('qfactor', 6.3, un.degC),
+        ul.Property('tendegrees', 10.0, un.degC),
+        ul.Property('alpha_m_A', -0.1, un.unitless / (un.ms * un.mV)),
+        ul.Property('alpha_m_V0', -40.0, un.mV),
+        ul.Property('alpha_m_K', 10.0, un.mV),
+        ul.Property('beta_m_A', 4.0, un.unitless / un.ms),
+        ul.Property('beta_m_V0', -65.0, un.mV),
+        ul.Property('beta_m_K', 18.0, un.mV),
+        ul.Property('alpha_h_A', 0.07, un.unitless / un.ms),
+        ul.Property('alpha_h_V0', -65.0, un.mV),
+        ul.Property('alpha_h_K', 20.0, un.mV),
+        ul.Property('beta_h_A', 1.0, un.unitless / un.ms),
+        ul.Property('beta_h_V0', -35.0, un.mV),
+        ul.Property('beta_h_K', 10.0, un.mV),
+        ul.Property('alpha_n_A', -0.01, un.unitless / (un.ms * un.mV)),
+        ul.Property('alpha_n_V0', -55.0, un.mV),
+        ul.Property('alpha_n_K', 10.0, un.mV),
+        ul.Property('beta_n_A', 0.125, un.unitless / un.ms),
+        ul.Property('beta_n_V0', -65.0, un.mV),
+        ul.Property('beta_n_K', 80.0, un.mV)]
 
-    analog_ports = [al.AnalogSendPort("V"), al.AnalogReducePort("Isyn",
-                                                                operator="+")]
+    analog_ports = [al.AnalogSendPort("V", un.voltage),
+                    al.AnalogReducePort("Isyn", un.current, operator="+")]
 
     c1 = al.DynamicsClass("HodgkinHuxley",
                           parameters=parameters,
+                          state_variables=state_variables,
                           regimes=(hh_regime,),
                           aliases=aliases,
                           constants=constants,

--- a/examples/NineML_import_test.py
+++ b/examples/NineML_import_test.py
@@ -83,7 +83,7 @@ def get_HH_component():
     analog_ports = [al.AnalogSendPort("V", un.voltage),
                     al.AnalogReducePort("Isyn", un.current, operator="+")]
 
-    c1 = al.DynamicsClass("HodgkinHuxley",
+    c1 = al.Dynamics("HodgkinHuxley",
                           parameters=parameters,
                           state_variables=state_variables,
                           regimes=(hh_regime,),
@@ -124,7 +124,7 @@ def get_Izh_component():
         al.StateVariable('V', un.voltage),
         al.StateVariable('U', un.voltage / un.time)]
 
-    c1 = al.DynamicsClass(
+    c1 = al.Dynamics(
         name="Izhikevich",
         parameters=parameters,
         state_variables=state_variables,
@@ -140,7 +140,7 @@ def get_Izh_FS_component():
     Load Fast spiking Izhikevich XML definition from file and parse into
     Abstraction Layer of Python API.
     """
-    izhi_fs = al.DynamicsClass(
+    izhi_fs = al.Dynamics(
         name='IzhikevichFS',
         parameters=[
             al.Parameter('a', un.per_time),
@@ -205,7 +205,7 @@ def get_aeIF_component():
     ## tau_w   # adaptation time constant
     ## a, b    # adaptation parameters [muS, nA]
     """
-    aeIF = al.DynamicsClass(
+    aeIF = al.Dynamics(
         name="aeIF",
         parameters=[
             al.Parameter('C_m', un.capacitance),
@@ -244,9 +244,9 @@ def get_compound_component():
     """Cannot yet be implemented in PyDSTool
     """
     from nineml.abstraction.testing_utils import RecordValue
-    from nineml.abstraction import DynamicsClass, Regime, On, OutputEvent, AnalogSendPort, AnalogReducePort
+    from nineml.abstraction import Dynamics, Regime, On, OutputEvent, AnalogSendPort, AnalogReducePort
 
-    emitter = DynamicsClass(
+    emitter = Dynamics(
             name='EventEmitter',
             parameters=['cyclelength'],
             regimes=[
@@ -255,7 +255,7 @@ def get_compound_component():
                         't > tchange + cyclelength', do=[OutputEvent('emit'), 'tchange=t'])),
             ])
 
-    ev_based_cc = DynamicsClass(
+    ev_based_cc = Dynamics(
             name='EventBasedCurrentClass',
             parameters=['dur', 'i'],
             analog_ports=[AnalogSendPort('I')],
@@ -269,12 +269,12 @@ def get_compound_component():
             ]
         )
 
-    pulsing_emitter = DynamicsClass(name='pulsing_cc',
+    pulsing_emitter = Dynamics(name='pulsing_cc',
                                          subnodes={'evs': emitter, 'cc': ev_based_cc},
                                          portconnections=[('evs.emit', 'cc.inputevent')]
                                          )
 
-    nrn = DynamicsClass(
+    nrn = Dynamics(
             name='LeakyNeuron',
             parameters=['Cm', 'gL', 'E'],
             regimes=[Regime('dV/dt = (iInj + (E-V)*gL )/Cm'), ],
@@ -283,7 +283,7 @@ def get_compound_component():
                           AnalogReducePort('iInj', operator='+')],
         )
 
-    combined_comp = DynamicsClass(name='Comp1',
+    combined_comp = Dynamics(name='Comp1',
                                        subnodes={
                                        'nrn': nrn,  'cc1': pulsing_emitter, 'cc2': pulsing_emitter},
                                        portconnections=[('cc1.cc.I', 'nrn.iInj'),


### PR DESCRIPTION
This PR updates PyDSTool's nineml import to match the the lib9ML PR https://github.com/INCF/lib9ML/pull/18. It also adds a script examples/NineMLCatalog_test.py, which runs the models tested in NineML_import_test.py but reads them from the NineMLCatalog (requires https://github.com/INCF/NineMLCatalog/pull/1).

Sorry if this is a little confusing, I will send an email about this shortly,
Cheers,
Tom