### PR TITLE
PyDSTool now creates models directory if directory does not already exist

### DIFF
--- a/PyDSTool/utils.py
+++ b/PyDSTool/utils.py
@@ -586,6 +586,9 @@ def saveObjects(objlist, filename, force=False):
     if not force:
         if os.path.isfile(filename):
             raise ValueError("File '" + filename + "' already exists")
+    dir = os.path.dirname(filename)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
     pklfile = open(filename, 'wb')
     opt = 0
     if not isinstance(objlist, list):


### PR DESCRIPTION
Fixes the following error in Fovea, scen1_game1.py

    Tool/utils.py", line 588, in saveObjects
    pklfile = open(filename, 'wb')
    FileNotFoundError: [Errno 2] No such file or directory:       /bombardier/models/sim_N5_fig1_dopri_ver1.sav'
