### PR TITLE
Fixed external phase delay issue described in …

### DIFF
--- a/PyDSTool/Generator/Vode_ODEsystem.py
+++ b/PyDSTool/Generator/Vode_ODEsystem.py
@@ -635,7 +635,7 @@ class Vode_ODEsystem(ODEsystem):
             num_points += 1
             if not breakwhile:
                 try:
-                    extralist[self.numpars:listend] = [f(solver.t + self.globalt0,
+                    extralist[self.numpars:listend] = [f(tmesh[0] + self.globalt0,
                                                          self.checklevel)
                                                        for f in inputVarList]
                 except ValueError:
@@ -654,7 +654,12 @@ class Vode_ODEsystem(ODEsystem):
                         'External input call caused t out of range error: t = %f'
                         % solver.t)
                     raise
-                solver.set_f_params(extralist)
+                except IndexError:
+                    # no points left in tmesh, move on and let re-loop catch and break
+                    # to end integration
+                    pass
+                else:
+                    solver.set_f_params(extralist)
                 breakwhile = not solver.successful()
         # Check that any terminal events found terminated the code correctly
         if first_found_t is not None:


### PR DESCRIPTION
VODE was looking ahead by one time sample when preparing next time step's external inputs for use in the RHS function. This fixes the primary issue described here:
https://sourceforge.net/p/pydstool/discussion/472291/thread/e55d28a2/