### PR TITLE
Bound SciPy version from above (<0.17)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "six",
-        "scipy>=0.9",
+        "scipy>=0.9,<0.17",
         "numpy>=1.6"
     ],
     tests_require=['pytest', 'mock', 'pytest-xdist'],


### PR DESCRIPTION
This is how SciPy is installed in .travis.yml.  Without this change, testing with tox doesn't work since PyDSTool cannot be imported now that SciPy 1.0.0 is released.

I don't think this patch is the best solution. I did this so that I can have testable branch comparable with pull request #132. But this may be a good short-term solution if PR #132 is not good enough.