### PR TITLE
Fix 'unknown escape sequence' errs by making certain strings raw strings

### DIFF
--- a/PyDSTool/FuncSpec.py
+++ b/PyDSTool/FuncSpec.py
@@ -274,13 +274,13 @@ class FuncSpec(object):
                                 'arithmetic operators')
         for s in term:
             if self.targetlang == 'python':
-                if s in '[]{}~@#$%&\|?^': # <>! now OK, e.g. for "if" statements
+                if s in r'[]{}~@#$%&\|?^': # <>! now OK, e.g. for "if" statements
                     print("Error in term:%s" % term)
                     raise ValueError('terms to be substituted must be '
                         'alphanumeric or contain arithmetic operators '
                         '+ - / *')
             else:
-                if s in '[]{}~!@#$%&\|?><': # removed ^ from this list
+                if s in r'[]{}~!@#$%&\|?><': # removed ^ from this list
                     print("Error in term:%s" % term)
                     raise ValueError('terms to be substituted must be alphanumeric or contain arithmetic operators + - / *')
         return True
@@ -290,7 +290,7 @@ class FuncSpec(object):
             print("Error in replacement term:%s" % repterm)
             raise ValueError('replacement terms must not begin with numbers')
         for s in repterm:
-            if s in '+-/*.()[]{}~!@#$%^&\|?><,':
+            if s in r'+-/*.()[]{}~!@#$%^&\|?><,':
                 print("Error in replacement term:%s" % repterm)
                 raise ValueError('replacement terms must be alphanumeric')
 

--- a/PyDSTool/Interval.py
+++ b/PyDSTool/Interval.py
@@ -30,7 +30,7 @@ import copy
 MIN_EXP = -15
 
 # type identifiers
-re_number = '([-+]?(\d+(\.\d*)?|\d*\.\d+)([eE][-+]?\d+)?)'
+re_number = r'([-+]?(\d+(\.\d*)?|\d*\.\d+)([eE][-+]?\d+)?)'
 
 c=1  # contained const
 n=0  # notcontained const

--- a/PyDSTool/parseUtils.py
+++ b/PyDSTool/parseUtils.py
@@ -155,7 +155,7 @@ __all__ = _functions + _classes + _objects + _constants + _symbfuncs + _symbcons
 #-----------------------------------------------------------------------------
 
 ## constants for parsing
-name_chars_RE = re.compile('\w')
+name_chars_RE = re.compile(r'\w')
 alphanumeric_chars_RE = re.compile('[a-zA-Z0-9]')   # without the '_'
 alphabet_chars_RE = re.compile('[a-zA-Z]')
 num_chars = [str(i) for i in range(10)]

--- a/tests/generator/test_oscillator.py
+++ b/tests/generator/test_oscillator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""
+r"""
     Simple forward integration test for ODE generators
 
     Comparing numerical results with exact solution


### PR DESCRIPTION
So e.g. backslashes in latex exprs or regexes not interpreted as unknown escape sequences